### PR TITLE
signature: use hmac.equal

### DIFF
--- a/signature.go
+++ b/signature.go
@@ -3,7 +3,6 @@ package session
 import (
 	"crypto/hmac"
 	"crypto/sha1"
-	"crypto/subtle"
 	"encoding/base64"
 )
 
@@ -16,7 +15,7 @@ func sign(value string, key []byte) string {
 
 func verify(value, digest string, keys [][]byte) bool {
 	for _, k := range keys {
-		if subtle.ConstantTimeCompare([]byte(digest), []byte(sign(value, k))) == 1 {
+		if hmac.Equal([]byte(digest), []byte(sign(value, k))) {
 			return true
 		}
 	}


### PR DESCRIPTION
`hmac.Equal` is same as `subtle.ConstantTimeCompare` :D